### PR TITLE
* Replaced deprecated .getDOMNode with ReactDOM.findDOMNode

### DIFF
--- a/lib/reactAutoComplete.js
+++ b/lib/reactAutoComplete.js
@@ -57,6 +57,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	"use strict";
 
 	var React = __webpack_require__(1);
+	var ReactDOM = __webpack_require__(!(function webpackMissingModule() { var e = new Error("Cannot find module \"react-DOM\""); e.code = 'MODULE_NOT_FOUND'; throw e; }()));
 	var joinClasses = __webpack_require__(2);
 
 	var Autocomplete = React.createClass({ displayName: "Autocomplete",
@@ -326,11 +327,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	  scrollToFocused: function () {
 	    var focused = this.refs && this.refs.focused;
 	    if (focused) {
-	      var containerNode = this.getDOMNode();
+	      var containerNode = ReactDOM.findDOMNode(this);
 	      var scroll = containerNode.scrollTop;
 	      var height = containerNode.offsetHeight;
 
-	      var node = focused.getDOMNode();
+	      var node = ReactDOM.findDOMNode(focused);
 	      var top = node.offsetTop;
 	      var bottom = top + node.offsetHeight;
 
@@ -356,7 +357,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      // we need to make sure focused node is visible
 	      // for some reason mouse events fire on visible nodes due to
 	      // box-shadow
-	      var containerNode = this.getDOMNode();
+	      var containerNode = ReactDOM.findDOMNode(this);
 	      var scroll = containerNode.scrollTop;
 	      var height = containerNode.offsetHeight;
 

--- a/src/__tests__/Autocomplete-test.js
+++ b/src/__tests__/Autocomplete-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React        = require('react');
+var ReactDOM     = require('react-dom');
 var assert       = require('assert');
 var sinon        = require('sinon');
 var TestUtils    = require('react-addons-test-utils');
@@ -25,25 +26,27 @@ describe('Autocomplete', function() {
 
   function getValueDOM(parent) {
     var input = getDOMAnyInputComponent(parent);
-    return input.value;
+    return ReactDOM.findDOMNode(input).value;
   }
 
   function setValueDOM(parent, text) {
       var input = getDOMAnyInputComponent(parent);
-      input.value = text;
+      ReactDOM.findDOMNode(input).value = text;
       TestUtils.Simulate.change(input);
   }
 
   function getResultsContainerDOM(component) {
-    return TestUtils.findRenderedDOMComponentWithClass(
+    var results = TestUtils.findRenderedDOMComponentWithClass(
       component,
       'react-autocomplete-Results');
+      
+    return ReactDOM.findDOMNode(results);
   }
 
   function getResultsDOM(component) {
     return TestUtils.scryRenderedDOMComponentsWithClass(
       component,
-      'react-autocomplete-Result').map((c) => c);
+      'react-autocomplete-Result').map((c) => ReactDOM.findDOMNode(c));
   }
 
   function assertResultsShown(component, shown) {
@@ -60,7 +63,7 @@ describe('Autocomplete', function() {
 
   it('should have "react-autocomplete" class', function() {
     var component = createAndMount({options: options});
-    var classes = component.refs.search.classList;
+    var classes = ReactDOM.findDOMNode(component).classList;
     assert.equal(classes.contains('react-autocomplete-Autocomplete'), true);
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 var React         = require('react');
+var ReactDOM      = require('react-DOM');
 var joinClasses   = require('classnames');
 
 var Autocomplete = React.createClass({
@@ -299,11 +300,11 @@ var Results = React.createClass({
   scrollToFocused: function() {
     var focused = this.refs && this.refs.focused;
     if (focused) {
-      var containerNode = this.getDOMNode();
+      var containerNode = ReactDOM.findDOMNode(this);
       var scroll = containerNode.scrollTop;
       var height = containerNode.offsetHeight;
 
-      var node = focused.getDOMNode();
+      var node = ReactDOM.findDOMNode(focused);
       var top = node.offsetTop;
       var bottom = top + node.offsetHeight;
 
@@ -329,7 +330,7 @@ var Results = React.createClass({
       // we need to make sure focused node is visible
       // for some reason mouse events fire on visible nodes due to
       // box-shadow
-      var containerNode = this.getDOMNode();
+      var containerNode = ReactDOM.findDOMNode(this);
       var scroll = containerNode.scrollTop;
       var height = containerNode.offsetHeight;
 


### PR DESCRIPTION
Added **require** for **ReactDOM** and replaced **.getDOMNode** with **ReactDOM.findDOMNode** in files:

- **src/__tests__/Autocomplete-test.js**
- **src/index.js**