### PR TITLE
Updated socket.io version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "classnames": "^1.2.0",
     "engine.io": "^1.5.1",
     "prop-types": "^15.6.0",
-    "socket.io-client": "^1.3.3"
+    "socket.io-client": "^2.3.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",


### PR DESCRIPTION
One of dependencies in old version has vulnerability coming from socket.io-client > engine.io-client > parsejson