### PR TITLE
Move browser-sync, engine.io, and socket.io-client to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,8 @@
     "autocomplete"
   ],
   "dependencies": {
-    "browser-sync": "^2.0.0-rc10",
     "classnames": "^1.2.0",
-    "engine.io": "^1.5.1",
-    "prop-types": "^15.6.0",
-    "socket.io-client": "^2.3.0"
+    "prop-types": "^15.6.0"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",
@@ -28,8 +25,9 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.24.1",
-    "browser-sync": "^1.9.0",
+    "browser-sync": "^2.0.0-rc10",
     "del": "^1.1.1",
+    "engine.io": "^1.5.1",
     "eslint-jsx": "git+https://github.com/andreypopp/eslint#jsx",
     "gulp": "^3.8.8",
     "gulp-autoprefixer": "1.0.1",
@@ -64,6 +62,7 @@
     "react-addons-test-utils": "^15.4.2",
     "run-sequence": "^1.0.2",
     "sinon": "^1.17.3",
+    "socket.io-client": "^2.3.0",
     "webpack": "^1.15.0"
   },
   "browserify": {


### PR DESCRIPTION
Raised a new Pull request due to merge conflicts.